### PR TITLE
KUI-1816: add support for different certs/configs in ref/prod

### DIFF
--- a/.azure/prod.parameters.json
+++ b/.azure/prod.parameters.json
@@ -18,7 +18,9 @@
         "LADOK3_DATABASE",
         "LADOK3_PASSWORD",
         "LADOK3_USERNAME",
-        "STUNNEL_HOST"
+        "STUNNEL_HOST",
+        "STUNNEL_CONFIGURATION_NAME",
+        "STUNNEL_CONFIGURATION_CONNECT_URL"
       ]
     },
     "environmentVariables": {

--- a/.azure/ref.parameters.json
+++ b/.azure/ref.parameters.json
@@ -18,7 +18,9 @@
         "LADOK3_DATABASE",
         "LADOK3_PASSWORD",
         "LADOK3_USERNAME",
-        "STUNNEL_HOST"
+        "STUNNEL_HOST",
+        "STUNNEL_CONFIGURATION_NAME",
+        "STUNNEL_CONFIGURATION_CONNECT_URL"
       ]
     },
     "environmentVariables": {

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,1 +1,1 @@
-FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/javascript-node:1-18-bullseye
+FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye

--- a/config/secrets/stunnel.conf.in
+++ b/config/secrets/stunnel.conf.in
@@ -1,9 +1,10 @@
 debug = 7
 foreground = yes
-[db2_ufhsk_Prod]
+[STUNNEL_CONFIGURATION_NAME]
 client = yes
 accept = 11000
-connect = kth.ufhsk.ladok.se.:2345
+delay = yes
+connect = STUNNEL_CONFIGURATION_CONNECT_URL
 key = ./config/secrets/kursstatistik-api@KTH.key
 # Verify the peer certificate against CA (CAfile)
 verify = 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "proxyquire": "^2.1.3"
       },
       "engines": {
-        "node": "18"
+        "node": "20"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/run.sh
+++ b/run.sh
@@ -5,6 +5,12 @@ echo $LADOK3_CERT | base64 -d > ./config/secrets/kursstatistik-api@KTH.crt && ch
 echo $LADOK3_CERT_KEY | base64 -d > ./config/secrets/kursstatistik-api@KTH.key && chmod 600 ./config/secrets/kursstatistik-api@KTH.key
 echo $CA_FILE | base64 -d > ./config/secrets/UF-prod-ca-bundle.txt && chmod 600 ./config/secrets/UF-prod-ca-bundle.txt
 
+# Copy fresh template
+cp ./config/secrets/stunnel.conf.in ./config/secrets/stunnel.conf 
+
+# Insert env-variables at predefined spots
+sed -i "s/STUNNEL_CONFIGURATION_NAME/${STUNNEL_CONFIGURATION_NAME}/g" ./config/secrets/stunnel.conf
+sed -i "s/STUNNEL_CONFIGURATION_CONNECT_URL/${STUNNEL_CONFIGURATION_CONNECT_URL}/g" ./config/secrets/stunnel.conf
 
 stunnel ./config/secrets/stunnel.conf 2>&1 &
 


### PR DESCRIPTION
We are going to use different certs/configs for ref and prod for kursstatistik-api from now on.

This had to be reflected in the stunnel.conf where we have to insert the correct URL and Configuration name for the respective config.